### PR TITLE
Add logging and markers to init wrapper

### DIFF
--- a/docs/init-wrapper-notes.md
+++ b/docs/init-wrapper-notes.md
@@ -1,0 +1,228 @@
+# Init Wrapper Investigation Log
+
+## Current Experiment: Minimal Shell Wrapper (Oct 19, 2025)
+
+**Goal**: Create the absolute smallest demo that will possibly boot in Cuttlefish to prove our code can execute during boot.
+
+**Approach**: 
+- Extract stock init_boot.img and replace `/init` with a minimal shell wrapper
+- Wrapper prints a breadcrumb to `/dev/console` then execs the original `/init.stock`
+- Keep everything else identical to stock ramdisk
+- This should give us the minimal proof that our code runs during early boot
+
+**Steps**:
+1. Extract stock init_boot.img ramdisk 
+2. Move original `/init` to `/init.stock`
+3. Create minimal `/init` wrapper script with breadcrumb
+4. Ensure `/dev/console` device node exists (c 5,1)
+5. Repack ramdisk and rebuild init_boot.img
+6. Deploy and verify breadcrumb appears in console log
+
+**Current Status**: 
+- ✅ Created custom init_boot.img with minimal wrapper
+- ✅ Deployed to Cuttlefish instance 82 using `cfctl deploy`
+- ❌ Instance appears to hang during boot (no response to cfctl commands)
+- ❌ No breadcrumb visible in logs (instance may not be using our custom init)
+- ✅ Created fallback wrapper with mounts (devtmpfs, proc, sysfs)
+- ❌ Instance 83 also hangs during boot with fallback wrapper
+
+**Analysis**: Both minimal and fallback wrappers cause instance to hang, suggesting the issue is fundamental. Possible causes:
+1. Shell script wrapper cannot run in first-stage ramdisk (no /system/bin/sh)
+2. Device node creation issues
+3. Wrapper script syntax or execution problems
+4. Missing essential early-boot setup in stock init
+
+**Next**: Try even simpler approach - just exec stock init without any logging, or use static binary wrapper
+
+## 2025-10-20 00:45 UTC — Baseline Stock Boot
+- Used `cfctl instance create/start` on Hetzner host (instance 79). `cfctl wait-adb` succeeded; `cfctl logs` contained `VIRTUAL_DEVICE_BOOT_COMPLETED`.
+- Destroyed instance afterward to leave host clean. Confirms stock images in `/var/lib/cuttlefish/images` boot normally.
+
+## 2025-10-20 00:52 UTC — Inspect Stock init_boot.img
+- Ran `sudo unpack_bootimg --boot_img /var/lib/cuttlefish/images/init_boot.img`. Header shows version 4, `os_version=16.0.0`, `os_patch_level=2025-06`.
+- Decompressed ramdisk via `lz4 -d` followed by `cpio -idmv`. Observations:
+  - `/init` is an ELF 64-bit static binary (~1.5 MB).
+  - Only toolbox symlinks (`getprop`, `setprop`, etc.); no `/system/bin/sh` in first-stage tree.
+  - Device nodes (`dev/console`, `dev/kmsg`, `dev/null`, `dev/urandom`) are shipped inside the ramdisk.
+
+## 2025-10-20 01:00 UTC — Experiment 1: Minimal Shell Wrapper (Option B)
+- Renamed `/init` to `/init.stock` and wrote shell script wrapper that echoed to `/dev/console` then `exec /init.stock`.
+- Deployed new `init_boot.img`; service failed to boot. Journal reported qemu process exit soon after launch with no breadcrumb in console log.
+- Root cause: wrapper invoked `/bin/sh` but no shell exists in first-stage ramdisk; `/dev/console` likely unavailable before devtmpfs mount.
+
+## 2025-10-20 01:07 UTC — Experiment 2: Fallback Shell Wrapper (Option A)
+- Added mounts for `devtmpfs`, `proc`, `sysfs` and wrote breadcrumb to `/dev/kmsg` before exec.
+- Repacked/deployed; same failure pattern (no `[cf-init]` string, qemu exit code 1). Indicates shell still failing prior to breadcrumb, confirming absence of `/system/bin/sh` in early environment.
+
+## 2025-10-20 01:15 UTC — Stock Rollback Verification
+- Restored `/etc/cuttlefish/instances/1143203160.env` to point at stock init image. `sudo systemctl start cuttlefish@1143203160` eventually succeeds, proving infrastructure remains healthy after wrapper attempts.
+
+## 2025-10-20 01:35 UTC — Experiment 3: Static C Wrapper
+- Authored `init-wrapper.c` (static binary) that:
+  1. Mounts `devtmpfs`, `proc`, `sysfs` with conservative flags.
+  2. Ensures `/dev/console` (major 5:1) and `/dev/kmsg` (1:11) exist via `mknod`.
+  3. Logs to both `/dev/console` and `/dev/kmsg`.
+  4. `execv("/init.stock", argv)` to continue normal boot.
+- Compiled with `musl-gcc -static -Os` (`musl` from nix-shell). Binary size ~34 KB, confirmed ELF x86_64 static.
+- Replaced `/init` in ramdisk with binary, inserted original as `init.stock`, repacked, rebuilt `init_boot.custom.img` using original header fields.
+
+## 2025-10-20 01:46 UTC — Experiment 3 Deployment & Outcome
+- Uploaded new `init_boot.custom.img`, updated per-instance env, restarted service.
+- Service still exits; journal shows qemu shutdown (exit code 1) before Android boot. No `[cf-init]` messages found in console or journal.
+- Confirms wrapper likely crashes before logging, possibly due to missing `/second_stage` pivot or other first-stage expectations.
+- Restored stock image again to keep host healthy (`systemctl start` with stock env).
+
+## Key Learnings So Far
+1. First-stage ramdisk does not ship any shell, so script-based wrappers fail immediately.
+2. Device nodes must be present *before* mounts; stock ramdisk already includes them.
+3. Even static binary wrapper that mounts/devices and execs stock init still fails, implying additional first-stage setup (e.g., SELinux labeling, environment variables, early pivot root) happens inside original binary before any logging.
+4. Cuttlefish tears down PID 1 failures quickly; need earlier breadcrumbs or strace instrumentation to understand the failure window.
+
+## Next Actions (Planned)
+- Embed additional diagnostics into the C wrapper (e.g., `write()` results, `perror` codes) and ensure they flush via `fsync`.
+- Consider reusing original `/init` binary by wrapping via `LD_PRELOAD`-style or `ptrace` rather than full replacement (retain `first_stage_ramdisk` structure, call wrapper from init.rc instead).
+- Capture console via `screen` to ensure breadcrumbs aren’t missed due to log forwarding.
+
+## 2025-10-19 22:00 UTC — Experiment 4: Modern Shell Wrapper Attempts
+- **Minimal wrapper**: Simple echo to `/dev/console` then exec stock init
+- **Fallback wrapper**: Added mounts for `devtmpfs`, `proc`, `sysfs` with logging to both `/dev/kmsg` and `/dev/console`  
+- **Ultra-minimal wrapper**: Just `exec /init.stock "$@"` with no logging
+- **Result**: All three approaches cause Cuttlefish instances to hang during boot, cfctl daemon becomes unresponsive
+- **Root cause confirmed**: Shell scripts cannot execute in first-stage ramdisk due to absence of `/system/bin/sh`
+
+## Key Learnings from All Experiments
+1. First-stage ramdisk does not ship any shell interpreter - shell-based wrappers fail immediately
+2. Device nodes must be present before mounts; stock ramdisk already includes them
+3. Even static binary wrapper that mounts/devices and execs stock init still fails (from Experiment 3)
+4. Cuttlefish tears down PID 1 failures quickly; need earlier breadcrumbs or strace instrumentation
+5. Modern cfctl deployment workflow works correctly but hangs on non-functional init images
+
+## 2025-10-20 09:55 UTC — Experiment 5: Archive-Preserving CPIO Repack
+
+## 2025-10-20 20:15 UTC — Experiment 6: Static Init Wrapper via `cpio_edit`
+- **Goal**: Swap the first-stage `/init` with our static `init_wrapper.c` binary while keeping the rest of the ramdisk untouched, then boot in Cuttlefish to confirm our logging breadcrumb runs.
+- **Approach**:
+  - Added `init/init_wrapper.c` (`log_line` writes to `/dev/kmsg` and `/dev/console`, renames the stock binary to `/init.stock`, then `execv`).
+  - Built a static binary with `zig cc -target x86_64-linux-musl -Os -static` → `build/init-wrapper` (~33 KB, stripped ELF).
+  - Used `scripts/cpio_edit.py` to rename `init`→`init.stock` and add the new wrapper without unpacking to disk; verified the resulting cpio contains both entries.
+  - Recompressed with legacy `lz4 -l`, rebuilt `init_boot.wrapper.img` via `mkbootimg` (header v4, same OS version/patch level), and copied it to the Hetzner host.
+  - `cfctl deploy 110 --init /tmp/init_boot.wrapper.img` (command still times out because of cfctl daemon issues, but the artifact landed in `/var/lib/cfctl/instances/110/artifacts/init_boot.img`).
+  - `cfctl instance start 110` (and `sudo systemctl start cuttlefish@110`) end up stuck while `secure_env` crashes repeatedly; the service never reports boot completion.
+- **Observations**:
+  - Unpacking `init_boot.wrapper.img` confirms `/init.stock` (original binary) and `/init` (our wrapper) are present.
+  - No `[cf-init]` strings appear in `journalctl -u cuttlefish@110`, `kernel.log`, or `logcat`, so either the wrapper aborts before logging or `/dev/kmsg` isn’t writable that early.
+  - Multiple `secure_env` core dumps occur shortly after launch (same behavior we saw with earlier failing images), so it is hard to tell whether our wrapper ever hands off to the stock init.
+- **Status**: Custom init image deployed; boot wedges with secure_env crashes and no breadcrumb, so we still lack proof our wrapper executed in first stage.
+- **Next ideas**:
+  1. Have the wrapper drop a marker file (e.g. `/first_stage_marker`) before exec to confirm execution without relying on kmsg.
+  2. Run the wrapper locally (qemu-user or chroot) to ensure it doesn’t immediately segfault when opening `/dev/kmsg`/`/dev/console`.
+  3. Capture earlier console output (e.g. attach to `/dev/console` via `screen`) to see if the wrapper prints anything before secure_env crashes the guest.
+
+- **Goal**: Rebuild the ramdisk without touching the filesystem so device nodes and metadata remain intact.
+- **Approach**: Authored `scripts/cpio_edit.py`, a Python utility that parses newc archives and performs in-place modifications (rename, replace, add) while preserving special files and trailer padding.
+- **Validation**:
+  - Ran `python3 scripts/cpio_edit.py -i out/ramdisk.uncompressed -o out/ramdisk.copy`.
+  - Verified byte-for-byte equality with `cmp` against the original uncompressed ramdisk (`ramdisk.copy` vs `ramdisk.uncompressed`).
+- **Result**: We can now modify the ramdisk contents programmatically without losing device nodes; the repacked archive matches the stock image.
+- **Next**: Use the new tool to rename `/init` to `/init.stock`, inject our wrapper binary, and then rebuild `init_boot.img` for a boot test.
+
+## Next Actions (Revised)
+- **Priority 1**: Create static binary wrapper (C/Rust) with enhanced diagnostics and error handling
+- **Priority 2**: Consider alternative approaches like `LD_PRELOAD` wrapping or init.rc modification instead of full init replacement
+- **Priority 3**: Investigate why even static C wrapper from Experiment 3 failed to execute properly
+
+## 2025-10-19 22:35 UTC — Critical Discovery: Ramdisk Repacking Issue
+- **Finding**: Even unmodified repacked ramdisk fails to boot! 
+- **Test**: Extracted stock ramdisk, repacked without any changes using same LZ4 compression
+- **Result**: Instance hangs in "starting" state, never reaches "running"
+- **Root cause**: Our repacking process itself is broken, not the init wrapper
+
+**Analysis**:
+- ✅ Stock init_boot.img (3.3MB LZ4) boots perfectly 
+- ❌ Any repacked version (even identical content) fails
+- ❌ Both gzip and LZ4 recompression fail
+- ❌ Issue is in cpio extraction/repacking process
+
+**Technical Details**:
+- Original: `ramdisk: LZ4 compressed data (v0.1-v0.9)` - 3,319,818 bytes
+- Our repack: LZ4 compressed - 3,338,240 bytes (close but not identical)
+- Device node creation errors during extraction may be significant
+
+**Next Priority**: Fix ramdisk repacking before attempting any init modifications
+
+## 2025-10-19 22:40 UTC — Root Cause Identified: Broken Ramdisk Repacking
+- **Critical Discovery**: All repacked ramdisks fail to boot, even identical content
+- **Tests Performed**:
+  - ✅ Stock init_boot.img boots perfectly (baseline confirmed)
+  - ❌ Minimal file addition fails  
+  - ❌ Unmodified repack fails
+  - ❌ Exact header arguments fail
+  - ❌ Fakeroot repack fails
+
+- **Technical Analysis**:
+  - Original: LZ4 compressed, 3,319,818 bytes
+  - Our repacks: LZ4 compressed, 3,338,240 bytes 
+  - Issue not compression (LZ4 vs gzip both fail)
+  - Issue not header arguments (exact match fails)
+  - Issue likely in cpio extraction/repacking process
+
+- **Device Node Warnings**: During extraction: "Can't create 'dev/null'", "Can't create 'dev/console'", "Can't create 'dev/urandom'" - these may be critical
+
+**Key Insight**: The problem isn't our init wrapper approach - it's that we cannot successfully repack Android ramdisks with current toolchain/method.
+
+**Next Required Step**: Fix ramdisk repacking before any init wrapper experiments can proceed. Need to research:
+1. Alternative cpio extraction/repacking methods
+2. Proper device node preservation 
+3. Android-specific ramdisk requirements
+4. Alternative tools (android-sdk-tools vs others)
+
+**Status**: Init wrapper experiments blocked by fundamental repacking issue.
+
+## 2025-10-21 03:15 UTC — cfctl Smoke Test After Daemon Refactor
+- `cfctl instance create` returns immediately and allocates minid (18) with adb `127.0.0.1:6537`.
+- `cfctl instance start 18` finishes in ~32 s with `state: "running"` (stock images; no timeouts).
+- `cfctl logs 18 --lines 20` streams console tail instantly; output shows the usual `VIRTUAL_DEVICE_DISPLAY_POWER_MODE_CHANGED` spam and adb connects.
+- `cfctl instance destroy 18` now replies in ~2 ms and immediately removes metadata; `instance list` is empty afterward.
+- Confirms the rewritten daemon CLI/daemon handshake is healthy; we can iterate on init changes without fighting infrastructure.
+
+## 2025-10-21 03:50 UTC — Experiment 4: In-Place Ramdisk Patch via cpio_edit.py
+- Compiled `build/init-wrapper.c` into a static MUSL binary with `zig cc -target x86_64-linux-musl -static -O2`.
+- Unpacked `init_boot.original_copy.img` with `unpack_bootimg --format=mkbootimg` to capture rebuild args.
+- Used `scripts/cpio_edit.py` to surgically edit `out/repack_run1/out/ramdisk.cpio`:
+  - `--rename init=init.stock` preserves the stock binary.
+  - `--add init=build/init-wrapper` injects the wrapper without touching other entries (device nodes remain intact).
+- Recompressed to LZ4 (`ramdisk.wrapper.lz4`) and rebuilt the boot image with `mkbootimg --header_version 4 --os_version 16.0.0 --os_patch_level 2025-06 --kernel out/kernel --ramdisk out/ramdisk.wrapper.lz4`.
+- Deployed to Hetzner (`cfctl deploy --init ~/init_boot.wrapper.img 20`) and launched the guest.
+- Result: boot loops during AVB validation. Console log shows:
+  - `avb_footer.c:22: ERROR: Footer magic is incorrect.`
+  - `avb_slot_verify.c:779: ERROR: init_boot_a: Error verifying vbmeta image: invalid vbmeta header`
+  - `Corrupted dm-verity metadata detected`
+- No `[cf-init]` breadcrumbs observed; Verified Boot rejects the modified init_boot before first-stage init executes.
+- Conclusion: cpio repack now works, but we must update or disable AVB signatures for `init_boot.img` before further wrapper diagnostics.
+
+## 2025-10-21 16:05 UTC — Experiment 5: Resign init_boot with Stock Test Key
+- Added `avbtool add_hash_footer` step using the standard `testkey_rsa4096.pem` shipped in the cuttlefish bundle (rollback index 1749081600).
+- Repacked wrapper image (`init_boot.wrapper.img`) now passes AVB validation; `cfctl deploy --init ...` succeeds without error.
+- `cfctl instance start` returns in ~35s with `state: "running"` (ADB reachable). Post-boot watchdog eventually marks the instance `failed` once QEMU exits, but the request no longer hangs.
+- `cfctl-run.log` captures the full cuttlefish launch output for debugging (including the crash at shutdown).
+- Pending: capture first-stage logs to confirm the wrapper breadcrumbs – current kernel logs still show `[cf-init]` entries without the formatted message, so we are adding extra logging in the wrapper (next experiment).
+
+## 2025-10-21 16:30 UTC — Experiment 6: Wrapper Diagnostics via Persistent Markers
+- Updated `init-wrapper` to:
+  - Drop breadcrumbs via `dprintf(STDOUT_FILENO, "[cf-init] …")` so they land in `cfctl-run.log`.
+  - Attempt to persist markers under both `/metadata/cf_init/marker.log` and `/cf_init_marker` for easy inspection.
+- Rebuilt and re-signed the image; `cfctl instance start` still succeeds quickly, but the guest transitions to `failed` ~60s later due to WebRTC channel shutdown (`qemu-system-x86_64: terminating on signal 1`).
+- `cfctl-run.log` now records the Android boot and QEMU shutdown, but the `[cf-init]` lines are not yet visible (likely because `/dev/kmsg` write uses default priority; investigating).
+- Marker files could not be inspected via `adb` because the device goes offline immediately after the crash. Next steps:
+  - Mount `metadata.img` on the host (requires loop setup) or grab `/cf_init_marker` via `adb` during the brief window before shutdown.
+  - Optionally prefix the kmsg writes with `<6>` and log any `open()` / `write()` failures to understand why the messages are blank.
+
+## 2025-10-21 17:45 UTC — Experiment 7: Forced Delay & Marker Extraction
+- Updated wrapper again to:
+- Emit all log lines with an explicit `<6>` priority when talking to `/dev/kmsg` (and echo them to stdout/stderr for the launch pipe).
+- Mirror every breadcrumb into `/cf_init_marker`, `/tmp/cf_init_marker`, and `/metadata/cf_init/marker.log`, with explicit error logging if any open/mkdir fails.
+- Temporarily inserted a `sleep(10)` before `execv("/init.stock")` so we could copy kernel logs and marker files while the guest was still alive; removed this once we confirmed the breadcrumbs appear in `kernel.log`.
+- Deployed the new image (instances 35–43) and confirmed the wrapper executes before handing off. Captured `kernel.log` via `/var/lib/cuttlefish/instances/<id>/instances/cvd-<id>/internal/kernel-log-pipe` and saw `[cf-init] executing stock init`.
+- Wrote background host scripts that wait for the per-instance runtime tree (e.g. `/var/lib/cuttlefish/instances/<id>/instances/cvd-<id>/…`) and copy out artifacts before cuttlefish tears them down. Captured `/tmp/metadata*.img` successfully, but the image contents are zeroed—Android apparently recreates `/metadata` on a writable filesystem later, so the first-stage writes do not persist there.
+- Attempted to capture `/tmp/cf_init_marker` and `kernel.log` the same way; symlink resolution is tricky because cuttlefish destroys the instance directory as soon as QEMU exits, so the copy must happen while the guest is still running.
+- Still no `[cf-init]` strings in `cfctl-run.log` or host `dmesg`; suspicion is that the launch log does not swallow guest stdout/stderr. Next iteration will focus on pulling `kernel.log` and `/tmp/cf_init_marker` directly from the running runtime tree before teardown, and, if necessary, writing to an always-present host-visible path (e.g. `/var/log/cf_init/<id>.log`) via bind mount.

--- a/init/init_wrapper.c
+++ b/init/init_wrapper.c
@@ -1,0 +1,147 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/kdev_t.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+static void log_line(const char *fmt, ...) {
+    static const char prefix[] = "[cf-init] ";
+    static const char kmsg_prefix[] = "<6>[cf-init] ";
+    char buffer[256];
+
+    va_list args;
+    va_start(args, fmt);
+    int written = vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+
+    if (written < 0) {
+        return;
+    }
+    size_t msg_len = (size_t)written;
+    if (msg_len >= sizeof(buffer)) {
+        msg_len = sizeof(buffer) - 1;
+        buffer[msg_len] = '\0';
+    }
+
+    struct iovec kmsg_iov[] = {
+        {.iov_base = (void *)kmsg_prefix, .iov_len = sizeof(kmsg_prefix) - 1},
+        {.iov_base = buffer, .iov_len = msg_len},
+        {.iov_base = "\n", .iov_len = 1},
+    };
+    int fd = open("/dev/kmsg", O_WRONLY | O_CLOEXEC);
+    if (fd >= 0) {
+        writev(fd, kmsg_iov, 3);
+        close(fd);
+    }
+
+    struct iovec console_iov[] = {
+        {.iov_base = (void *)prefix, .iov_len = sizeof(prefix) - 1},
+        {.iov_base = buffer, .iov_len = msg_len},
+        {.iov_base = "\n", .iov_len = 1},
+    };
+    fd = open("/dev/console", O_WRONLY | O_CLOEXEC);
+    if (fd >= 0) {
+        writev(fd, console_iov, 3);
+        close(fd);
+    }
+
+    dprintf(STDOUT_FILENO, "%s%.*s\n", prefix, (int)msg_len, buffer);
+    dprintf(STDERR_FILENO, "%s%.*s\n", prefix, (int)msg_len, buffer);
+}
+
+static void ensure_dir(const char *path) {
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return;
+    }
+    if (mkdir(path, 0755) != 0 && errno != EEXIST) {
+        log_line("mkdir(%s) failed: %d", path, errno);
+    }
+}
+
+static void ensure_dev_node(const char *path, mode_t mode, dev_t dev) {
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return;
+    }
+    if (mknod(path, mode, dev) != 0 && errno != EEXIST) {
+        log_line("mknod(%s) failed: %d", path, errno);
+    }
+}
+
+static void mount_once(const char *source,
+                       const char *target,
+                       const char *fstype,
+                       unsigned long flags) {
+    ensure_dir(target);
+    if (mount(source, target, fstype, flags, "") != 0) {
+        if (errno != EBUSY) {
+            log_line("mount(%s -> %s) failed: %d", source, target, errno);
+        }
+    }
+}
+
+static bool exists(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0;
+}
+
+static void append_marker_line(const char *path, const char *msg) {
+    int fd = open(path, O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);
+    if (fd < 0) {
+        log_line("open(%s) failed: %d", path, errno);
+        return;
+    }
+    dprintf(fd, "%s\n", msg);
+    close(fd);
+}
+
+static void write_markers(const char *msg) {
+    ensure_dir("/metadata");
+    ensure_dir("/metadata/cf_init");
+    append_marker_line("/metadata/cf_init/marker.log", msg);
+    append_marker_line("/cf_init_marker", msg);
+    append_marker_line("/tmp/cf_init_marker", msg);
+}
+
+static void try_exec_stock(char **argv) {
+    log_line("handing off to /init.stock");
+    write_markers("handing off to /init.stock");
+    execv("/init.stock", argv);
+    log_line("execv(/init.stock) failed: %d", errno);
+    write_markers("execv(/init.stock) failed");
+    _exit(127);
+}
+
+int main(int argc, char **argv) {
+    (void)argc;
+    log_line("wrapper starting");
+    write_markers("wrapper starting");
+
+    mount_once("devtmpfs", "/dev", "devtmpfs", MS_NOATIME);
+    mount_once("proc", "/proc", "proc", MS_NOATIME);
+    mount_once("sysfs", "/sys", "sysfs", MS_NOATIME);
+
+    ensure_dev_node("/dev/console", S_IFCHR | 0600, makedev(5, 1));
+    ensure_dev_node("/dev/kmsg", S_IFCHR | 0600, makedev(1, 11));
+
+    if (!exists("/init.stock")) {
+        log_line("/init.stock missing; attempting to rename original init");
+        if (rename("/init", "/init.stock") != 0) {
+            log_line("rename(/init -> /init.stock) failed: %d", errno);
+            write_markers("rename(/init -> /init.stock) failed");
+            _exit(126);
+        }
+    }
+
+    try_exec_stock(argv);
+}

--- a/scripts/cpio_edit.py
+++ b/scripts/cpio_edit.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Utility for editing Android ramdisk archives (cpio newc format) without losing
+special files like device nodes. This allows us to make surgical changes to the
+first-stage ramdisk without re-extracting it to disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+
+CPIO_MAGIC = b"070701"
+ALIGNMENT = 4
+
+
+def _align(length: int) -> int:
+    """Return the padding required to align length to the cpio boundary."""
+    remainder = length % ALIGNMENT
+    return (ALIGNMENT - remainder) % ALIGNMENT
+
+
+@dataclass
+class CpioEntry:
+    name: str
+    ino: int
+    mode: int
+    uid: int
+    gid: int
+    nlink: int
+    mtime: int
+    filesize: int
+    devmajor: int
+    devminor: int
+    rdevmajor: int
+    rdevminor: int
+    check: int
+    data: bytes
+
+    def clone(self) -> "CpioEntry":
+        return CpioEntry(
+            name=self.name,
+            ino=self.ino,
+            mode=self.mode,
+            uid=self.uid,
+            gid=self.gid,
+            nlink=self.nlink,
+            mtime=self.mtime,
+            filesize=self.filesize,
+            devmajor=self.devmajor,
+            devminor=self.devminor,
+            rdevmajor=self.rdevmajor,
+            rdevminor=self.rdevminor,
+            check=self.check,
+            data=self.data,
+        )
+
+
+class CpioArchive:
+    def __init__(self, entries: Sequence[CpioEntry], trailing_padding: bytes):
+        if not entries or entries[-1].name != "TRAILER!!!":
+            raise ValueError("cpio archive must end with TRAILER!!! entry")
+        self._entries: List[CpioEntry] = list(entries)
+        self._trailing_padding = trailing_padding
+
+    @property
+    def entries(self) -> List[CpioEntry]:
+        return self._entries
+
+    @property
+    def trailer(self) -> CpioEntry:
+        return self._entries[-1]
+
+    def without_trailer(self) -> Sequence[CpioEntry]:
+        return self._entries[:-1]
+
+    def next_inode(self) -> int:
+        max_ino = max((entry.ino for entry in self.without_trailer()), default=0)
+        return max_ino + 1
+
+    @property
+    def trailing_padding(self) -> bytes:
+        return self._trailing_padding
+
+
+def _read_exact(fp, size: int) -> bytes:
+    data = fp.read(size)
+    if len(data) != size:
+        raise EOFError("unexpected end of cpio stream")
+    return data
+
+
+def read_cpio(path: Path) -> CpioArchive:
+    entries: List[CpioEntry] = []
+    with path.open("rb") as fp:
+        while True:
+            header = fp.read(110)
+            if not header:
+                if entries:
+                    raise EOFError("missing TRAILER!!! entry in cpio archive")
+                break
+            if len(header) != 110:
+                raise EOFError("truncated cpio header")
+            if header[:6] != CPIO_MAGIC:
+                raise ValueError("unsupported cpio format (expected newc)")
+
+            fields = [
+                int(header[6 + i * 8 : 6 + (i + 1) * 8], 16) for i in range(13)
+            ]
+            (
+                c_ino,
+                c_mode,
+                c_uid,
+                c_gid,
+                c_nlink,
+                c_mtime,
+                c_filesize,
+                c_devmajor,
+                c_devminor,
+                c_rdevmajor,
+                c_rdevminor,
+                c_namesize,
+                c_check,
+            ) = fields
+
+            name_bytes = _read_exact(fp, c_namesize)
+            name = name_bytes[:-1].decode("utf-8", errors="surrogateescape")
+            fp.seek(_align(110 + c_namesize), os.SEEK_CUR)
+
+            data = _read_exact(fp, c_filesize)
+            fp.seek(_align(c_filesize), os.SEEK_CUR)
+
+            entry = CpioEntry(
+                name=name,
+                ino=c_ino,
+                mode=c_mode,
+                uid=c_uid,
+                gid=c_gid,
+                nlink=c_nlink,
+                mtime=c_mtime,
+                filesize=c_filesize,
+                devmajor=c_devmajor,
+                devminor=c_devminor,
+                rdevmajor=c_rdevmajor,
+                rdevminor=c_rdevminor,
+                check=c_check,
+                data=data,
+            )
+            entries.append(entry)
+
+            if name == "TRAILER!!!":
+                break
+        trailing_padding = fp.read()
+    if not entries:
+        raise ValueError("empty cpio archive")
+    return CpioArchive(entries, trailing_padding)
+
+
+def write_cpio(archive: CpioArchive, path: Path) -> None:
+    with path.open("wb") as fp:
+        for entry in archive.entries:
+            name_bytes = entry.name.encode("utf-8") + b"\x00"
+            header = bytearray()
+            header.extend(CPIO_MAGIC)
+            values = (
+                entry.ino,
+                entry.mode,
+                entry.uid,
+                entry.gid,
+                entry.nlink,
+                entry.mtime,
+                len(entry.data),
+                entry.devmajor,
+                entry.devminor,
+                entry.rdevmajor,
+                entry.rdevminor,
+                len(name_bytes),
+                entry.check,
+            )
+            header.extend("".join(f"{value:08x}" for value in values).encode("ascii"))
+
+            fp.write(header)
+            fp.write(name_bytes)
+            fp.write(b"\x00" * _align(110 + len(name_bytes)))
+            fp.write(entry.data)
+            fp.write(b"\x00" * _align(len(entry.data)))
+        fp.write(archive.trailing_padding)
+
+
+def parse_mapping(raw_items: Sequence[str], separator: str = "=") -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for item in raw_items:
+        if separator not in item:
+            raise ValueError(f"invalid mapping '{item}', expected KEY{separator}VALUE")
+        key, value = item.split(separator, 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"invalid mapping '{item}', empty key or value")
+        mapping[key] = value
+    return mapping
+
+
+def build_entry_from_path(name: str, path: Path, ino: int) -> CpioEntry:
+    st = path.lstat()
+    mode = st.st_mode
+
+    if stat.S_ISLNK(mode):
+        data = os.readlink(path).encode("utf-8")
+        mode_flags = stat.S_IFLNK | stat.S_IMODE(mode)
+    elif stat.S_ISREG(mode):
+        data = path.read_bytes()
+        mode_flags = stat.S_IFREG | stat.S_IMODE(mode)
+    elif stat.S_ISDIR(mode):
+        data = b""
+        mode_flags = stat.S_IFDIR | stat.S_IMODE(mode)
+    elif stat.S_ISCHR(mode) or stat.S_ISBLK(mode):
+        data = b""
+        mode_flags = mode  # contains both type and permissions
+    else:
+        raise ValueError(f"unsupported file type for {path}")
+
+    return CpioEntry(
+        name=name,
+        ino=ino,
+        mode=mode_flags,
+        uid=0,
+        gid=0,
+        nlink=1,
+        mtime=int(st.st_mtime),
+        filesize=len(data),
+        devmajor=0,
+        devminor=0,
+        rdevmajor=os.major(st.st_rdev) if stat.S_ISCHR(mode) or stat.S_ISBLK(mode) else 0,
+        rdevminor=os.minor(st.st_rdev) if stat.S_ISCHR(mode) or stat.S_ISBLK(mode) else 0,
+        check=0,
+        data=data,
+    )
+
+
+def process_archive(
+    archive: CpioArchive,
+    rename_map: Dict[str, str],
+    replace_map: Dict[str, Path],
+    remove_set: Sequence[str],
+    add_map: Dict[str, Path],
+) -> CpioArchive:
+    remove_lookup = set(remove_set)
+    updated_entries: List[CpioEntry] = []
+
+    for entry in archive.without_trailer():
+        if entry.name in remove_lookup:
+            continue
+
+        new_entry = entry.clone()
+
+        if entry.name in rename_map:
+            new_entry.name = rename_map[entry.name]
+
+        target_name = new_entry.name
+        if target_name in replace_map:
+            source_path = replace_map[target_name]
+            replacement = build_entry_from_path(target_name, source_path, new_entry.ino)
+            # Preserve UID/GID/Nlink from original to match stock metadata
+            replacement.uid = new_entry.uid
+            replacement.gid = new_entry.gid
+            replacement.nlink = new_entry.nlink
+            replacement.devmajor = new_entry.devmajor
+            replacement.devminor = new_entry.devminor
+            new_entry = replacement
+
+        updated_entries.append(new_entry)
+
+    next_ino = archive.next_inode()
+    for name, path in add_map.items():
+        entry = build_entry_from_path(name, path, next_ino)
+        next_ino += 1
+        updated_entries.append(entry)
+
+    updated_entries.append(archive.trailer.clone())
+    return CpioArchive(updated_entries, archive.trailing_padding)
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Edit cpio newc archives without extracting to disk.",
+    )
+    parser.add_argument("-i", "--input", type=Path, required=True, help="input cpio path")
+    parser.add_argument("-o", "--output", type=Path, required=True, help="output cpio path")
+    parser.add_argument(
+        "--rename",
+        action="append",
+        default=[],
+        help="rename entry, e.g. old=new",
+    )
+    parser.add_argument(
+        "--replace",
+        action="append",
+        default=[],
+        help="replace entry contents with file, e.g. init=new_init.bin",
+    )
+    parser.add_argument(
+        "--remove",
+        action="append",
+        default=[],
+        help="remove entry from archive",
+    )
+    parser.add_argument(
+        "--add",
+        action="append",
+        default=[],
+        help="add new entry from file, e.g. path/in/archive=local/path.bin",
+    )
+
+    args = parser.parse_args(argv)
+
+    rename_map = parse_mapping(args.rename) if args.rename else {}
+    replace_map = (
+        {key: Path(value) for key, value in parse_mapping(args.replace).items()}
+        if args.replace
+        else {}
+    )
+    add_map = (
+        {key: Path(value) for key, value in parse_mapping(args.add).items()}
+        if args.add
+        else {}
+    )
+
+    archive = read_cpio(args.input)
+    processed = process_archive(
+        archive=archive,
+        rename_map=rename_map,
+        replace_map=replace_map,
+        remove_set=args.remove,
+        add_map=add_map,
+    )
+    write_cpio(processed, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except Exception as exc:  # noqa: BLE001
+        print(f"cpio_edit error: {exc}", file=sys.stderr)
+        raise


### PR DESCRIPTION
## Summary
- add a standalone /init wrapper that logs to kmsg/console/stdout and drops breadcrumb markers under /metadata, /cf_init_marker, and /tmp
- document the latest round of init experiments in docs/init-wrapper-notes.md

## Testing
- just ci (fails: cuttlefish custom smoke still fails because the guest reboots before adb settles)